### PR TITLE
Add set none of prekey operation

### DIFF
--- a/rust/protocol/src/sealed_sender.rs
+++ b/rust/protocol/src/sealed_sender.rs
@@ -794,7 +794,7 @@ pub async fn sealed_sender_encrypt<R: Rng + CryptoRng>(
     now: SystemTime,
     rng: &mut R,
 ) -> Result<Vec<u8>> {
-    let message = message_encrypt(ptext, destination, session_store, identity_store, now).await?;
+    let message = message_encrypt(ptext, destination, session_store, identity_store, now, None).await?;
     let usmc = UnidentifiedSenderMessageContent::new(
         message.0.message_type(),
         sender_cert.clone(),

--- a/rust/protocol/src/session_cipher.rs
+++ b/rust/protocol/src/session_cipher.rs
@@ -23,6 +23,7 @@ pub async fn message_encrypt(
     session_store: &mut dyn SessionStore,
     identity_store: &mut dyn IdentityKeyStore,
     now: SystemTime,
+    is_kdf: Option<bool>,
 ) -> Result<(
     CiphertextMessage,
     Option<String>,
@@ -154,6 +155,11 @@ pub async fn message_encrypt(
         return Err(SignalProtocolError::UntrustedIdentity(
             remote_address.clone(),
         ));
+    }
+
+    let is_kdf = is_kdf.unwrap_or(false);
+    if is_kdf {
+        session_state.clear_unacknowledged_pre_key_message();
     }
 
     // XXX this could be combined with the above call to the identity store (in a new API)

--- a/rust/protocol/src/session_cipher.rs
+++ b/rust/protocol/src/session_cipher.rs
@@ -72,6 +72,11 @@ pub async fn message_encrypt(
                 SignalProtocolError::InvalidSessionStructure("invalid sender chain message keys")
             })?;
 
+    let is_kdf = is_kdf.unwrap_or(false);
+    if is_kdf {
+        session_state.clear_unacknowledged_pre_key_message();
+    }
+
     let message = if let Some(items) = session_state.unacknowledged_pre_key_message_items()? {
         let timestamp_as_unix_time = items
             .timestamp()
@@ -155,11 +160,6 @@ pub async fn message_encrypt(
         return Err(SignalProtocolError::UntrustedIdentity(
             remote_address.clone(),
         ));
-    }
-
-    let is_kdf = is_kdf.unwrap_or(false);
-    if is_kdf {
-        session_state.clear_unacknowledged_pre_key_message();
     }
 
     // XXX this could be combined with the above call to the identity store (in a new API)


### PR DESCRIPTION
When create session, one always send prekey msgs if other one does not reply, so you can set prekey none when needs.